### PR TITLE
Fix for multiselect actions on Symfony 4

### DIFF
--- a/Datatable/Column/MultiselectColumn.php
+++ b/Datatable/Column/MultiselectColumn.php
@@ -191,13 +191,26 @@ class MultiselectColumn extends ActionColumn
     {
         if (count($actions) > 0) {
             foreach ($actions as $action) {
-                $newAction = new MultiselectAction($this->datatableName);
-                $this->actions[] = $newAction->set($action);
+                $this->addAction($action);
             }
         } else {
             throw new Exception('MultiselectColumn::setActions(): The actions array should contain at least one element.');
         }
 
+        return $this;
+    }
+    
+    /**
+     * Add action.
+     *
+     * @param array $action
+     *
+     * @return $this
+     */
+    public function addAction(array $action)
+    {
+        $newAction = new MultiselectAction($this->datatableName);
+        $this->actions[] = $newAction->set($action);
         return $this;
     }
 


### PR DESCRIPTION
Symfony 4's PropertyAccessor uses primary add* method for adding properties, not set*. Since MultiselectColumn is derived from ActionColumn and MultiselectColumn didn't have a addAction method, PropertyAccessor uses addAction method from ActionColumn class, that creates Action objects, not MultiselectAction objects.